### PR TITLE
feat: reduce parallels

### DIFF
--- a/website/build_data.ts
+++ b/website/build_data.ts
@@ -25,6 +25,30 @@ for (const file of jsonSourceFiles) {
         const additionalContent = JSON.parse(additionalBuffer.toString())
         fileContent = deepmerge(fileContent, additionalContent)
     }
+    if (file === 'cards_ja') {
+        // Merge Paralle cards with original entry
+        const fileContentReduced = {...fileContent}
+        for (const key in fileContentReduced) {
+            fileContentReduced[key].parallels = []
+            if (!key.startsWith('B')) {
+                continue;
+            }
+            let regularKey = ''
+            if (key.endsWith('P')) { // regular parallel
+                regularKey = key.replace(/P$/, '')
+            }
+            if (key.endsWith('Sec2')) { // regular parallel
+                regularKey = key.replace(/Sec2$/, 'Sec1')
+            }
+            if (!regularKey) {
+                continue;
+            }
+            fileContentReduced[regularKey].parallels.push(key)
+            delete fileContentReduced[key]
+        }
+        const reducedTargetPath = path.join('data/', file + '_reduced.json')
+        fs.writeFileSync(reducedTargetPath, JSON.stringify(fileContentReduced))
+    }
     if (file === 'products_ja') {
         fileContent = Object.fromEntries(
             Object.entries(fileContent).sort(([k1], [k2]) => k1 < k2 ? -1 : 1),

--- a/website/layouts/page/cards.html
+++ b/website/layouts/page/cards.html
@@ -156,7 +156,7 @@
 
     <div class="card-list flex flex-wrap justify-start mt-4">
         {{ $counter := 0 }}
-        {{ range site.Data.cards_ja }}
+        {{ range site.Data.cards_ja_reduced }}
         {{ $card := . }}
         {{ $title := or (T (printf "cards.%s.title" .card_id )) .title }}
         {{ $type := or (T (printf "types.%s" .type )) .type }}
@@ -173,6 +173,16 @@
         {{ $categories := slice }}
         {{range .categories}}{{ $categories = $categories | append (or (T (printf "categories.%s" . )) .) }}{{end}}
 
+        {{ $parallels := slice }}
+        {{range $card.parallels}}
+            {{ $parallelCardNum := . }}
+            {{ with or (resources.Get (printf "cards/%s.ja.jpg" $parallelCardNum)) (resources.Get "img/fallback.jpg") }}
+                {{ with .Resize "250x" }}
+                    {{ $parallels = $parallels | append (dict "card_num" $parallelCardNum "image"  .RelPermalink) }}
+                {{ end }}
+            {{ end }}
+        {{end}}
+
         {{ with or (resources.Get (printf "cards/%s.ja.jpg" $card.card_num)) (resources.Get "img/fallback.jpg") }}
             {{ with .Resize "250x" }}
                 <dct-card
@@ -180,6 +190,7 @@
                         image="{{ .RelPermalink }}"
                         title="{{ $title }}"
                         original-title="{{ $card.title }}"
+                        parallels="{{ $parallels | jsonify }}"
                         card-id="{{ $card.card_id }}"
                         card-num="{{ $card.card_num }}"
                         promo-details="{{ $contain }}"

--- a/website/static/js/script.js
+++ b/website/static/js/script.js
@@ -31,6 +31,7 @@ class Card extends HTMLElement {
         rarity: '',
         promoDetails: '',
         categories: [],
+        parallels: [],
         cost: 0,
         ap: 0,
         lp: 0,
@@ -55,6 +56,7 @@ class Card extends HTMLElement {
         this.data.color = this.getAttribute('color')
         this.data.rarity = this.getAttribute('rarity')
         this.data.categories = this.getAttribute('categories').split(',')
+        this.data.parallels = this.getAttribute('parallels').split(',')
         this.data.cost = this.getAttribute('cost')
         this.data.ap = this.getAttribute('ap')
         this.data.lp = this.getAttribute('lp')
@@ -207,12 +209,24 @@ class Card extends HTMLElement {
                 </div>`;
         }
 
+        let images = `
+        <figure>
+            <img src="${this.data.image}" alt="${this.data.title} (${this.data.cardNum})" class="rounded-xl" style="max-width: unset;" loading="lazy" />
+        </figure>`
+        for (const parallel of JSON.parse(this.data.parallels)) {
+            console.log(parallel)
+            images += `
+        <figure>
+            <img src="${parallel.image}" alt="${this.data.title} (${parallel.card_num})" class="rounded-xl" style="max-width: unset;" loading="lazy" />
+        </figure>`
+        }
+
         container.innerHTML += `<div data-popover id="card-${this.data.id}" role="tooltip"
      class="absolute z-10 invisible inline-block text-sm transition-opacity duration-300 border border-gray-200 rounded-lg shadow-lg opacity-0 dark:border-gray-600 bg-white dark:bg-warmgray-800 dark:text-white"
 >
     <div class="flex items-start">
         <div class="cardoverlay-image self-stretch">
-            <img src="${this.data.image}" alt="${this.data.title} (${this.data.cardNum})" class="rounded-xl" style="max-width: unset;" loading="lazy" />
+            ${images}
         </div>
         <!-- Add color here as well for mobile view -->
         <div class="dark:border-gray-600 bg-white dark:bg-warmgray-800 dark:text-white" style="min-width: 550px;max-width: 550px;">


### PR DESCRIPTION
Not sure how to go about this.

Set 1 and 2 parallels aren't really different.
Also some promo cards have a foil version, which are exactly the same but have a separate card number.

Set 3 will have actual alternate artworks, so combining parallels with the regular cards,
making the card art visible when clicking on the base art seems not really a great idea then.

Also, the filter for parallel cards would then not have an effect. Maybe a separate "has parallel" checkbox could replace those.